### PR TITLE
Implement rules DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ If successful, it will print out a message and exit with code 0.
 
 If not successful, it will print out validation errors and terminate with a nonzero code
 
+## Configuration
+
+Configuration is provided via a policy rules DSL file.  This is a JSON document that containes rules which govern which policies apply to a given
+submission.  Documentation can be found in [its concrete design doc](https://docs.google.com/document/d/1cPNN9TFUCLX-4yVoRuhmM0Vcrh3WYWNs-rwAszuJWXk/edit#heading=h.sae8awmp6ter)
+
+An example of such configuration file can be found in the [test data](rule/testdata/good.json)
+
 ## Building
 
 Building the policy service requires go 1.12 or later.

--- a/cmd/pass-policy-service/validate.go
+++ b/cmd/pass-policy-service/validate.go
@@ -39,7 +39,7 @@ func validateAction(args []string) error {
 		return errors.Wrapf(err, "error opening file")
 	}
 
-	err = rule.Validate(content)
+	_, err = rule.Validate(content)
 	if err == nil {
 		log.Println("Validation OK")
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/oa-pass/pass-policy-service
 go 1.12
 
 require (
+	github.com/go-test/deep v1.0.1
 	github.com/gobuffalo/packr/v2 v2.1.0
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/qri-io/jsonschema v0.0.0-20190413152851-094d15abc20e
 	github.com/sergi/go-diff v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/urfave/cli v1.20.0
 	golang.org/x/tools v0.0.0-20190411180116-681f9ce8ac52 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
+github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/envy v1.6.15 h1:OsV5vOpHYUpP7ZLS6sem1y40/lNX1BZj+ynMiRi21lQ=

--- a/rule/condition.go
+++ b/rule/condition.go
@@ -1,7 +1,6 @@
 package rule
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -104,7 +103,6 @@ func eachPair(src interface{}, variables VariableResolver, test func(string, str
 			return false, errors.Errorf("given a %T instead of a string", src)
 		}
 
-		fmt.Printf("resolving %s and %s\n", a, b)
 		if a, err = singleValued(variables.Resolve(a)); err != nil {
 			return false, errors.Wrapf(err, "could not resolve variable %s", a)
 		}
@@ -130,7 +128,7 @@ func singleValued(list []string, err error) (string, error) {
 	}
 
 	if len(list) != 1 {
-		return "", errors.New("expecing single valued string")
+		return "", errors.Errorf("expecting single valued string, instead got %+v", list)
 	}
 
 	return list[0], nil

--- a/rule/condition.go
+++ b/rule/condition.go
@@ -1,0 +1,10 @@
+package rule
+
+type Condition map[string]interface{}
+
+func (c Condition) apply(variables VariableResolver) (bool, error) {
+	if c == nil {
+		return true, nil
+	}
+	return false, nil
+}

--- a/rule/condition.go
+++ b/rule/condition.go
@@ -1,10 +1,137 @@
 package rule
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Condition in the policy rules DSL is a json object that determines whether a policy applies or not.
+// It is generally of the form
+//     {
+//        "anyOf": [
+//           {"equals":{"one": "two"}},
+//           {"endsWith":{"one": "gone"}}
+//        ]
+//     }
 type Condition map[string]interface{}
 
-func (c Condition) apply(variables VariableResolver) (bool, error) {
-	if c == nil {
-		return true, nil
+type evaluation func(interface{}, VariableResolver) (bool, error)
+
+var evaluators map[string]evaluation
+
+func init() {
+	evaluators = map[string]evaluation{
+		"endsWith": endsWith,
+		"equals":   equals,
+		"anyOf":    anyOf,
 	}
+}
+
+// Apply evaluates a condition using the given variable resolver.
+func (c Condition) Apply(variables VariableResolver) (bool, error) {
+
+	for cond, val := range c {
+		eval, ok := evaluators[cond]
+		if !ok {
+			return false, errors.Errorf("unknown condition %s", cond)
+		}
+
+		passes, err := eval(val, variables)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not evaluate condition '%s'", cond)
+		}
+
+		if !passes {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func endsWith(fromCondition interface{}, variables VariableResolver) (bool, error) {
+
+	return eachPair(fromCondition, variables, strings.HasSuffix)
+}
+
+func equals(fromCondition interface{}, variables VariableResolver) (bool, error) {
+
+	return eachPair(fromCondition, variables, func(a, b string) bool {
+		return a == b
+	})
+}
+
+func anyOf(arg interface{}, variables VariableResolver) (bool, error) {
+	list, ok := arg.([]interface{})
+	if !ok {
+		return false, errors.Errorf("expecting a list, but got %T", arg)
+	}
+
+	for _, item := range list {
+		obj, ok := item.(map[string]interface{})
+		if !ok {
+			return false, errors.Errorf("expecting a JSON object as list item, but got %T", arg)
+		}
+
+		passes, err := Condition(obj).Apply(variables)
+		if err != nil {
+			return false, errors.Wrap(err, "condition failed to apply")
+		}
+
+		if passes {
+			return true, nil
+		}
+	}
+
 	return false, nil
+}
+
+func eachPair(src interface{}, variables VariableResolver, test func(string, string) bool) (passes bool, err error) {
+	operands, ok := src.(map[string]interface{})
+	if !ok {
+		return false, errors.Errorf("expecting a JSON object, instead got a %T", src)
+	}
+
+	// If there's no resolver, just pass through.
+	if variables == nil {
+		variables = passThroughResolver{}
+	}
+
+	for b, thing := range operands {
+		a, ok := thing.(string)
+		if !ok {
+			return false, errors.Errorf("given a %T instead of a string", src)
+		}
+
+		fmt.Printf("resolving %s and %s\n", a, b)
+		if a, err = singleValued(variables.Resolve(a)); err != nil {
+			return false, errors.Wrapf(err, "could not resolve variable %s", a)
+		}
+		if b, err = singleValued(variables.Resolve(b)); err != nil {
+			return false, errors.Wrapf(err, "could not resolve variable %s", b)
+		}
+
+		if !test(a, b) {
+			return false, err
+		}
+	}
+
+	return true, err
+}
+
+func singleValued(list []string, err error) (string, error) {
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	if len(list) == 0 {
+		return "", nil
+	}
+
+	if len(list) != 1 {
+		return "", errors.New("expecing single valued string")
+	}
+
+	return list[0], nil
 }

--- a/rule/condition_test.go
+++ b/rule/condition_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestConditionApply(t *testing.T) {
 	variables := testResolver(map[string][]string{
-		"${one.spelled}": []string{"one"},
-		"${none}":        []string{},
+		"${one.spelled}": {"one"},
+		"${none}":        {},
 	})
 
 	cases := []struct {
@@ -113,7 +113,7 @@ func TestConditionErrors(t *testing.T) {
 				"equals": {"${bar}": "foo"}
 			}`,
 			resolver: testResolver(map[string][]string{
-				"${bar}": []string{"foo", "bar"},
+				"${bar}": {"foo", "bar"},
 			}),
 		},
 		"anyOf is not a list": {

--- a/rule/condition_test.go
+++ b/rule/condition_test.go
@@ -1,0 +1,157 @@
+package rule_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/oa-pass/pass-policy-service/rule"
+)
+
+func TestConditionApply(t *testing.T) {
+	variables := testResolver(map[string][]string{
+		"${one.spelled}": []string{"one"},
+		"${none}":        []string{},
+	})
+
+	cases := []struct {
+		json     string
+		expected bool
+	}{{
+		expected: true,
+		json: `{
+			"anyOf": [
+				{"equals":{"one": "two"}},
+				{"endsWith":{"one": "gone"}}
+			]
+		}`,
+	}, {
+		expected: false,
+		json: `{
+			"anyOf": [
+				{"equals":{"one": "two"}},
+				{"endsWith":{"one": "goner"}}
+			]
+		}`,
+	}, {
+		expected: false,
+		json:     `{"equals":{"one": "two"}}`,
+	}, {
+		expected: true,
+		json:     `{"equals":{"two": "two"}}`,
+	}, {
+		expected: true,
+		json: `{
+			"equals": {"one": "${one.spelled}"},
+			"endsWith": {"${one.spelled}": "gone"}
+		}`,
+	}, {
+		expected: false,
+		json: `{
+			"equals": {"one": "one"},
+			"endsWith": {"one": "goner"}
+		}`,
+	}, {
+		expected: false,
+		json: `{
+				"equals": {"one": "${none}"}
+			}`,
+	}}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.json, func(t *testing.T) {
+			parsed := make(map[string]interface{})
+			err := json.Unmarshal([]byte(c.json), &parsed)
+			if err != nil {
+				t.Fatalf("bad test data, does not parse:\n%s\n  reason: %s", c.json, err)
+			}
+
+			passed, err := rule.Condition(parsed).Apply(variables)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			if passed != c.expected {
+				t.Fatalf("passed: %t, but expected %t", passed, c.expected)
+			}
+		})
+	}
+}
+
+func TestConditionErrors(t *testing.T) {
+
+	cases := map[string]struct {
+		json     string
+		resolver rule.VariableResolver
+	}{
+		"bad JSON": {json: `{
+			"good"
+			"bad
+		}`},
+		"no such condition": {json: `{
+			"squareRoot": {"2": "4"}
+		}`},
+		"bad operands": {json: `{
+			"equals": {"2": ["3", "5"]}
+		}`},
+		"bad operands 2": {json: `{
+			"equals": 7
+		}`},
+		"variable resolving error 1": {
+			json: `{
+				"equals": {"foo": "${bar}"}
+			}`,
+			resolver: errResolver{},
+		},
+		"variable resolving error 2": {
+			json: `{
+				"equals": {"${bar}": "foo"}
+			}`,
+			resolver: errResolver{},
+		},
+		"variable resolves to a list": {
+			json: `{
+				"equals": {"${bar}": "foo"}
+			}`,
+			resolver: testResolver(map[string][]string{
+				"${bar}": []string{"foo", "bar"},
+			}),
+		},
+		"anyOf is not a list": {
+			json: `{
+				"anyOf": {"foo": "bar"}
+			}`,
+		},
+		"anyOf is a heterogeneous list": {
+			json: `{
+				"anyOf": [
+					{"equals":{"one": "two"}},
+					"hello"
+				]
+			}`,
+		},
+		"anyOf resolving error": {
+			json: `{
+				"anyOf": [
+					{"equals":{"one": "two"}},
+					{"endsWith":{"one": "${bar}"}}
+				]
+			}`,
+			resolver: errResolver{},
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			parsed := make(map[string]interface{})
+
+			err := json.Unmarshal([]byte(c.json), &parsed)
+			if err == nil {
+				_, err := rule.Condition(parsed).Apply(c.resolver)
+				if err == nil {
+					t.Fatal("should have failed with an error")
+				}
+			}
+		})
+	}
+}

--- a/rule/conditions.go
+++ b/rule/conditions.go
@@ -1,3 +1,0 @@
-package rule
-
-type Condition map[string]interface{}

--- a/rule/context.go
+++ b/rule/context.go
@@ -46,7 +46,7 @@ func (c *Context) Resolve(vari string) ([]string, error) {
 
 	v, ok := toVariable(vari)
 	if !ok {
-		return nil, errors.Errorf("'%s' is not a variable of the form ${foo.bar.baz}", vari)
+		return []string{vari}, nil
 	}
 
 	// Resolve each part of the variable (e.g. a, a.b, a.b.c, a.b.c.d)
@@ -272,7 +272,7 @@ func (c *Context) resolveToObjects(v variable, vals []string) error {
 }
 
 func uniq(vals []string) []string {
-	var uniqueVals []string
+	uniqueVals := []string{}
 	encountered := make(map[string]bool, len(vals))
 
 	for _, str := range vals {

--- a/rule/context.go
+++ b/rule/context.go
@@ -1,0 +1,287 @@
+package rule
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Known variable names
+const (
+	SubmissionVariable = "submission" // ${submission}
+	HeaderVariable     = "header"     // ${header}
+)
+
+// PassEntityFetcher retrieves the JSON-LD content at the given url, and
+// un-marshals it into the provided struct.
+//
+// entityPointer is expected to be a pointer to a struct or map
+// (i.e. anything encoding/json can un-marshal into).  An error will be returned
+// otherwise.
+type PassEntityFetcher interface {
+	FetchEntity(url string, entityPointer interface{}) error
+}
+
+// resolvedObject contains a parsed JSON object, as well as the source
+// URI from where it came
+type resolvedObject struct {
+	src    string
+	object map[string]interface{}
+}
+
+// Context establishes a rule evaluation/resolution context.
+type Context struct {
+	SubmissionURI string
+	Headers       map[string][]string
+	PassClient    PassEntityFetcher
+	values        map[string]interface{} // values that have been already resolved
+}
+
+// Resolve resolves a variable of the form ${a.b.c.d}, returning
+// a list of strings.
+func (c *Context) Resolve(vari string) ([]string, error) {
+
+	c.init()
+
+	v, ok := toVariable(vari)
+	if !ok {
+		return nil, errors.Errorf("'%s' is not a variable of the form ${foo.bar.baz}", vari)
+	}
+
+	// Resolve each part of the variable (e.g. a, a.b, a.b.c, a.b.c.d)
+	for part, ok := v.shift(); ok; part, ok = part.shift() {
+		err := c.resolvePart(part)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not resolve variable part %s", part.segmentName)
+		}
+	}
+
+	// Now materialize the resolved value(s?) into a list of strings
+	switch v := c.values[v.fullName].(type) {
+	case string:
+		return []string{v}, nil
+	case resolvedObject:
+		return []string{v.src}, nil
+	case []string:
+		return uniq(v), nil
+	case []resolvedObject:
+		var vals []string
+		for _, val := range v {
+			vals = append(vals, val.src)
+		}
+		return uniq(vals), nil
+	case nil:
+		return []string{}, nil
+	}
+
+	return nil, errors.Errorf("variable %s resolved to a %T instead of a string", v.fullName, c.values[v.fullName])
+
+}
+
+// Set the ${submission} and ${header} values, if not set already
+func (c *Context) init() {
+
+	// if the values map is already initialized, we're done
+	if c.values != nil {
+		return
+	}
+
+	c.values = map[string]interface{}{
+		SubmissionVariable: c.SubmissionURI,
+	}
+
+	headers := make(map[string]interface{}, len(c.Headers))
+	for k, v := range c.Headers {
+		headers[k] = v
+	}
+	c.values[HeaderVariable] = resolvedObject{object: headers}
+}
+
+// Resolve a variable part (e.g ${x.y} out of ${x.y.z})
+func (c *Context) resolvePart(varPart variable) (err error) {
+
+	// If we already have a value, no need to re-resolve it  Likewise, no point in
+	// resolving ${} from ${x}
+	if _, ok := c.values[varPart.segmentName]; ok || varPart.prev().segmentName == "" {
+		return nil
+	}
+
+	// We need to resolve the previous segment into a map, (or list of maps) if it isn't already,
+	// and extract its value
+	switch prevValue := c.values[varPart.prev().segmentName].(type) {
+
+	// ${foo} is a JSON object, or list of JSON objects, or a JSON blobs that had previously been resolved from URIs.
+	// So just look up key 'bar' and save those values to ${foo.bar}
+	case resolvedObject:
+		err = c.extractValue(varPart, prevValue)
+	case []resolvedObject:
+		err = c.extractValues(varPart, prevValue)
+
+	// ${foo} is a string, or list of strings.  In order to find ${foo.bar},
+	// see if each foo is a stringified JSON blob, or an http uri.
+	// If it's a blob, parse to a JSON object and save it as a resolvedObject to ${foo.bar}.
+	// If it is a URI, dereference it and, if it a JSON blob, parse it to a JSON object
+	// and save a resolvedObject containing both the URI and the resulting blob to ${foo.bar}
+	case string:
+		if err = c.resolveToObject(varPart.prev(), prevValue); err != nil {
+			return errors.Wrapf(err, "could not resolve %s to an object in ${%s}", prevValue, varPart.prev().segmentName)
+		}
+		err = c.resolvePart(varPart)
+	case []string:
+		if err = c.resolveToObjects(varPart.prev(), prevValue); err != nil {
+			return errors.Wrapf(err, "could not resolve all uris in ${%s}", varPart.prev().segmentName)
+		}
+		err = c.resolvePart(varPart)
+
+	// ${foo} is a list of some sort, but we don't know the type of the items.  If they are URIs, dereference the URIs.
+	// If the result is a JSON blob, parse it and look up the value of the key 'bar' in each blob.  Save to ${foo.bar}
+	case []interface{}:
+		var list []string
+		for _, item := range prevValue {
+			s, ok := item.(string)
+			if !ok {
+				return errors.Errorf("expecting list items to be strings, instead got %T", item)
+			}
+			list = append(list, s)
+		}
+
+		if err = c.resolveToObjects(varPart.prev(), list); err != nil {
+			return errors.Wrapf(err, "could not resolve all uris in ${%s}", varPart.prev().segmentName)
+		}
+		err = c.resolvePart(varPart)
+
+	// ${bar} is has no value, so of course ${foo.bar} has no value either
+	case nil:
+		c.values[varPart.segmentName] = []string{}
+		c.values[varPart.segment] = []string{}
+
+	// ${bar} is some unexpected type.
+	default:
+		return errors.Errorf("%s is %T, cannot parse into an object to extract %s",
+			varPart.prev().segmentName,
+			prevValue,
+			varPart.segmentName,
+		)
+	}
+
+	return err
+}
+
+// Set ${foo.bar} to foo[bar]
+func (c *Context) extractValue(v variable, resolved resolvedObject) error {
+
+	val, ok := resolved.object[v.segment]
+	if !ok {
+		c.values[v.segmentName] = []string{}
+		c.values[v.segment] = []string{}
+	}
+
+	c.values[v.segmentName] = val
+	c.values[v.segment] = val // this is the shortcut ${properties}, instead of ${x.y.properties}
+
+	return nil
+}
+
+// Append foo[bar] to ${foo.bar} for each foo
+func (c *Context) extractValues(v variable, resolvedList []resolvedObject) error {
+	var vals []string
+
+	for _, resolved := range resolvedList {
+		if val, ok := resolved.object[v.segment]; ok {
+
+			switch typedVal := val.(type) {
+			case string:
+				vals = append(vals, typedVal)
+			case []interface{}:
+				for _, item := range typedVal {
+					strval, ok := item.(string)
+					if !ok {
+						return errors.Errorf("%s is a list of %T, not strings", v.segmentName, item)
+					}
+					vals = append(vals, strval)
+				}
+			default:
+				return errors.Errorf("%s is a %T, not a string", v.segmentName, val)
+			}
+		}
+	}
+
+	if len(vals) == 0 {
+		return errors.Errorf("no values of %s have key %s", v.prev().segmentName, v.segment)
+	}
+
+	c.values[v.segmentName] = vals
+	c.values[v.segment] = vals // this is the shortcut ${properties}, instead of ${x.y.properties}
+
+	return nil
+}
+
+// resolve a string to an object.  This will only work if the string is a
+// http URI, or a JSON blob
+func (c *Context) resolveToObject(v variable, s string) error {
+
+	resolved := resolvedObject{
+		src:    s,
+		object: make(map[string]interface{}, 10),
+	}
+
+	c.values[v.segmentName] = resolved
+	c.values[v.segment] = resolved
+
+	// If it's a URI, try resolving it
+	if strings.HasPrefix(s, "http") {
+		return c.PassClient.FetchEntity(s, &resolved.object)
+	}
+
+	// Otherwise, attempt to decode it as a JSON blob
+
+	return json.Unmarshal([]byte(s), &resolved.object)
+}
+
+// resolve each of a list of strins to an object.  This will only work if each string is a
+// http URI, or a JSON blob
+func (c *Context) resolveToObjects(v variable, vals []string) error {
+	var objs []resolvedObject
+
+	for _, s := range vals {
+		resolved := resolvedObject{
+			src:    s,
+			object: make(map[string]interface{}, 10),
+		}
+		// If it's a URI, try resolving it
+		if strings.HasPrefix(s, "http") {
+			if err := c.PassClient.FetchEntity(s, &resolved.object); err != nil {
+				return errors.Wrapf(err, "error fetching %s", s)
+			}
+		} else {
+
+			err := json.Unmarshal([]byte(s), &resolved.object)
+			if err != nil {
+				return errors.Wrap(err, "error parsing json blob")
+			}
+		}
+
+		objs = append(objs, resolved)
+	}
+
+	c.values[v.segmentName] = objs
+	c.values[v.segment] = objs
+
+	return nil
+}
+
+func uniq(vals []string) []string {
+	var uniqueVals []string
+	encountered := make(map[string]bool, len(vals))
+
+	for _, str := range vals {
+		_, ok := encountered[str]
+		if !ok {
+			uniqueVals = append(uniqueVals, str)
+			encountered[str] = true
+		}
+	}
+
+	return uniqueVals
+}

--- a/rule/context_test.go
+++ b/rule/context_test.go
@@ -1,0 +1,249 @@
+package rule_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/oa-pass/pass-policy-service/rule"
+)
+
+// map of urls to json strings
+type testFetcher map[string]string
+
+// deserialize the json string into the given entity pointer
+func (f testFetcher) FetchEntity(url string, entityPointer interface{}) error {
+	jsonBlob, ok := f[url]
+	if !ok {
+		return fmt.Errorf("no value for key %s", url)
+	}
+
+	return json.Unmarshal([]byte(jsonBlob), entityPointer)
+}
+
+func TestContextResolve(t *testing.T) {
+	submissionURI := "http://example.org/submissionUri"
+
+	cases := []struct {
+		testName      string
+		fetcher       testFetcher
+		headers       map[string][]string
+		varName       string
+		expectedValue []string
+	}{{
+		testName: "noValue",
+		varName:  "${submission.baz}",
+		fetcher: map[string]string{
+			submissionURI: `{
+				"foo":"bar",
+				"not":"used"
+			}`,
+		},
+		expectedValue: []string{},
+	}, {
+		testName:      "submission",
+		varName:       "${submission}",
+		expectedValue: []string{submissionURI},
+	}, {
+		testName: "submissionProperty",
+		varName:  "${submission.foo}",
+		fetcher: map[string]string{
+			submissionURI: `{
+				"foo":"bar",
+				"not":"used"
+			}`,
+		},
+		expectedValue: []string{"bar"},
+	}, {
+		testName: "headerProperty",
+		varName:  "${header.foo}",
+		headers: map[string][]string{
+			"foo": {"bar"},
+		},
+		expectedValue: []string{"bar"},
+	}, {
+		testName: "jsonStringProperty",
+		varName:  "${submission.foo.bar}",
+		fetcher: map[string]string{
+			submissionURI: `{
+				"foo":"{\"bar\":\"baz\"}"
+			}`,
+		},
+		expectedValue: []string{"baz"},
+	}, {
+		testName: "traverseSingleObjects",
+		varName:  "${submission.foo.bar}",
+		fetcher: map[string]string{
+			submissionURI: `{
+				"foo": "https:/example.org/foo/1" 
+			}`,
+			"https:/example.org/foo/1": `{
+				"bar": "http://example.org/baz"
+			}`,
+		},
+		expectedValue: []string{"http://example.org/baz"},
+	}, {
+		testName: "traverseSingleListObjects",
+		varName:  "${submission.foo.bar}",
+		fetcher: map[string]string{
+			submissionURI: `{
+				"foo": ["http:/example.org/singleGrant"] 
+			}`,
+			"http:/example.org/singleGrant": `{
+				"bar": "http://example.org/directFunder"
+			}`,
+		},
+		expectedValue: []string{"http://example.org/directFunder"},
+	}, {
+		testName: "traverseManyListObjects",
+		varName:  "${submission.foo.bar.rhubarb}",
+		fetcher: map[string]string{
+			submissionURI: `{
+				"foo": [
+					"http:/example.org/foo/1",
+					"http:/example.org/foo/2"
+				] 
+			}`,
+			"http:/example.org/foo/1": `{
+				"bar": [
+					"http:/example.org/bar/1",
+					"http:/example.org/bar/2"
+				]
+			}`,
+			"http:/example.org/foo/2": `{
+				"bar": [
+					"http:/example.org/bar/1",
+					"http:/example.org/bar/3"
+				]
+			}`,
+			"http:/example.org/bar/1": `{
+				"rhubarb": [
+					"a",
+					"b"
+				]
+			}`,
+			"http:/example.org/bar/2": `{
+				"rhubarb": [
+					"b",
+					"c"
+				]
+			}`,
+			"http:/example.org/bar/3": `{
+				"rhubarb": [
+					"d",
+					"e"
+				]
+			}`,
+		},
+		expectedValue: []string{"a", "b", "c", "d", "e"},
+	}}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.testName, func(t *testing.T) {
+			cxt := rule.Context{
+				SubmissionURI: submissionURI,
+				PassClient:    c.fetcher,
+				Headers:       c.headers,
+			}
+
+			vals, err := cxt.Resolve(c.varName)
+			if err != nil {
+				t.Fatalf("Error resolving variable %s: %+v", c.varName, err)
+			}
+
+			diffs := deep.Equal(vals, c.expectedValue)
+			if len(diffs) != 0 {
+				t.Fatalf("Found differences in expected values: %s", strings.Join(diffs, "\n"))
+			}
+
+		})
+	}
+}
+
+// Use the same context for multiple variable resolutions
+func TestContextMultipleResolve(t *testing.T) {
+
+	submissionURI := "http://example.org/submission"
+
+	varNames := []string{
+		"${submission.foo.bar.rhubarb}",
+		"${submission.foo}",
+		"${submission.foo.moo}",
+		"${submission.foo.bar.rhubarb}",
+	}
+
+	expectedValues := []interface{}{
+		[]string{"a", "b", "c", "d", "e"},
+		[]string{
+			"http:/example.org/foo/1",
+			"http:/example.org/foo/2",
+		},
+		[]string{"cow"},
+		[]string{"a", "b", "c", "d", "e"},
+	}
+
+	fetcher := testFetcher(map[string]string{
+		submissionURI: `{
+				"foo": [
+					"http:/example.org/foo/1",
+					"http:/example.org/foo/2"
+				]
+			}`,
+		"http:/example.org/foo/1": `{
+				"bar": [
+					"http:/example.org/bar/1",
+					"http:/example.org/bar/2"
+				], 
+				"moo": "cow"
+			}`,
+		"http:/example.org/foo/2": `{
+				"bar": [
+					"http:/example.org/bar/1",
+					"http:/example.org/bar/3"
+				]
+			}`,
+		"http:/example.org/bar/1": `{
+				"rhubarb": [
+					"a",
+					"b"
+				]
+			}`,
+		"http:/example.org/bar/2": `{
+				"rhubarb": [
+					"b",
+					"c"
+				]
+			}`,
+		"http:/example.org/bar/3": `{
+				"rhubarb": [
+					"d",
+					"e"
+				]
+			}`,
+	})
+
+	cxt := rule.Context{
+		SubmissionURI: submissionURI,
+		PassClient:    fetcher,
+	}
+
+	for i, v := range varNames {
+		v := v
+		i := i
+		t.Run(v, func(t *testing.T) {
+
+			vals, err := cxt.Resolve(v)
+			if err != nil {
+				t.Fatalf("Error resolving variable %s: %+v", v, err)
+			}
+
+			diffs := deep.Equal(vals, expectedValues[i])
+			if len(diffs) != 0 {
+				t.Fatalf("Found differences in expected values: %s", strings.Join(diffs, "\n"))
+			}
+		})
+	}
+}

--- a/rule/dsl.go
+++ b/rule/dsl.go
@@ -6,8 +6,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Document encapsulates to a policy rules document
-type Document struct {
+// DSL encapsulates to a policy rules document
+type DSL struct {
 	Schema   string   `json:"$schema"`
 	Policies []Policy `json:"policy-rules"`
 }
@@ -26,7 +26,7 @@ func Resolve(doc []byte, variables VariableResolver) ([]Policy, error) {
 		return nil, errors.Wrapf(err, "invalid input policy doc")
 	}
 
-	rules := &Document{}
+	rules := &DSL{}
 	_ = json.Unmarshal(doc, rules)
 
 	var policies []Policy

--- a/rule/dsl.go
+++ b/rule/dsl.go
@@ -1,8 +1,6 @@
 package rule
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 )
 
@@ -12,26 +10,17 @@ type DSL struct {
 	Policies []Policy `json:"policy-rules"`
 }
 
-// VariableResolver resolves a variable (a string of form "${foo.bar.baz}"), and returns
-// a list of values
-type VariableResolver interface {
-	Resolve(varString string) ([]string, error)
-}
-
 // Resolve parses a policy rules document into a set of concrete rules, with all
 // variables interpolated
-func Resolve(doc []byte, variables VariableResolver) ([]Policy, error) {
-	err := Validate(doc)
+func Resolve(doc []byte, variables VariablePinner) ([]Policy, error) {
+	rules, err := Validate(doc)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid input policy doc")
 	}
 
-	rules := &DSL{}
-	_ = json.Unmarshal(doc, rules)
-
 	var policies []Policy
 	for _, policy := range rules.Policies {
-		resolved, err := policy.resolve(variables)
+		resolved, err := policy.Resolve(variables)
 		if err != nil {
 			return policies, errors.Wrapf(err, "could not resolve policy rule")
 		}

--- a/rule/dsl_test.go
+++ b/rule/dsl_test.go
@@ -1,0 +1,90 @@
+package rule_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/oa-pass/pass-policy-service/rule"
+)
+
+func TestDSL(t *testing.T) {
+	submissionURI := "http://example.org/submission"
+
+	json := `{
+		"$schema": "https://oa-pass.github.io/pass-policy-service/schemas/policy_config_1.0.json",
+		"policy-rules": [
+			{
+				"description": "Used for unit testing",
+				"policy-id": "${submission.foo.policy}",
+				"conditions": [
+					{
+						"endsWith": {
+							"good": "${submission.foo.policy}"
+						}
+					}
+				],
+				"repositories": [
+					{
+						"repository-id": "${policy.repository}",
+						"selected": true
+					}
+				]
+			},
+			{
+				"description": "Used for unit testing",
+				"policy-id": "http://example.org/policy",
+				"repositories": [
+					{
+						"repository-id": "http://example.org/repository",
+						"selected": true
+					}
+				]
+			}
+		]
+	}`
+
+	policies, err := rule.Resolve([]byte(json), &rule.Context{
+		SubmissionURI: submissionURI,
+		PassClient: testFetcher(map[string]string{
+			submissionURI: `{
+				"foo": [
+					"http://example.org/foo/1",
+					"http://example.org/foo/2"
+				]
+			}`,
+			"http://example.org/foo/1": `{
+				"policy": "http://example.org/policy/1"
+			}`,
+			"http://example.org/foo/2": `{
+				"policy": "http://example.org/policy/2-good"
+			}`,
+			"http://example.org/policy/1": `{
+				"repository": ["a", "b"]
+			}`,
+			"http://example.org/policy/2-good": `{
+				"repository": ["c", "d"]
+			}`,
+		}),
+	})
+
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	if len(policies) != 2 {
+		t.Fatalf("Wrong number of policies %d", len(policies))
+	}
+
+	var repos []string
+	for _, p := range policies {
+		for _, r := range p.Repositories {
+			repos = append(repos, r.ID)
+		}
+	}
+
+	diffs := deep.Equal(repos, []string{"c", "d", "http://example.org/repository"})
+	if len(diffs) > 0 {
+		t.Fatalf("Found differences in expected repositories: %s", strings.Join(diffs, "\n"))
+	}
+}

--- a/rule/engine.go
+++ b/rule/engine.go
@@ -1,6 +1,42 @@
 package rule
 
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// Document encapsulates to a policy rules document
 type Document struct {
 	Schema   string   `json:"$schema"`
 	Policies []Policy `json:"policy-rules"`
+}
+
+// VariableResolver resolves a variable (a string of form "${foo.bar.baz}"), and returns
+// a list of values
+type VariableResolver interface {
+	Resolve(varString string) ([]string, error)
+}
+
+// Resolve parses a policy rules document into a set of concrete rules, with all
+// variables interpolated
+func Resolve(doc []byte, variables VariableResolver) ([]Policy, error) {
+	err := Validate(doc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid input policy doc")
+	}
+
+	rules := &Document{}
+	_ = json.Unmarshal(doc, rules)
+
+	var policies []Policy
+	for _, policy := range rules.Policies {
+		resolved, err := policy.resolve(variables)
+		if err != nil {
+			return policies, errors.Wrapf(err, "could not resolve policy rule")
+		}
+		policies = append(policies, resolved...)
+	}
+
+	return policies, nil
 }

--- a/rule/policy.go
+++ b/rule/policy.go
@@ -1,8 +1,74 @@
 package rule
 
+import (
+	"github.com/pkg/errors"
+)
+
 type Policy struct {
 	ID           string       `json:"policy-id"`
 	Description  string       `json:"description"`
 	Repositories []Repository `json:"repositories"`
 	Conditions   []Condition  `json:"conditions"`
+}
+
+func (p Policy) resolve(vaiables VariableResolver) (policies []Policy, err error) {
+
+	var resolvedPolicies []Policy
+
+	if IsVariable(p.ID) {
+		resolvedIDs, err := vaiables.Resolve(p.ID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not resolve property ID %s", p.ID)
+		}
+
+		for _, id := range resolvedIDs {
+
+			resolved, err := Policy{
+				ID:           id,
+				Description:  p.Description,
+				Repositories: p.Repositories,
+				Conditions:   p.Conditions,
+			}.resolve(vaiables)
+
+			if err != nil {
+				return nil, errors.Wrapf(err, "could not resolve policy rule for %s", id)
+			}
+
+			resolvedPolicies = append(resolvedPolicies, resolved...)
+		}
+	} else {
+		resolvedPolicies = []Policy{p}
+		if p.Repositories, err = p.resolveRepositories(vaiables); err != nil {
+			return nil, errors.Wrapf(err, "could not resolve repositories in policy %s", p.ID)
+		}
+
+		if ok, err := p.applyConditions(vaiables); ok && err != nil {
+			resolvedPolicies = append(resolvedPolicies)
+		}
+	}
+
+	return resolvedPolicies, nil
+}
+
+func (p Policy) resolveRepositories(variables VariableResolver) ([]Repository, error) {
+	var resolved []Repository
+	for _, repo := range p.Repositories {
+		repos, err := repo.Resolve(variables)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not resolve repositories for %s", p.ID)
+		}
+
+		resolved = append(resolved, repos...)
+	}
+	return resolved, nil
+}
+
+func (p Policy) applyConditions(variables VariableResolver) (bool, error) {
+	for _, cond := range p.Conditions {
+		if ok, err := cond.apply(variables); !ok || err != nil {
+			return ok, err
+		}
+	}
+
+	return true, nil
 }

--- a/rule/policy.go
+++ b/rule/policy.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Policy encapsulates a policy rule.
 type Policy struct {
 	ID           string       `json:"policy-id"`
 	Description  string       `json:"description"`
@@ -11,10 +12,14 @@ type Policy struct {
 	Conditions   []Condition  `json:"conditions"`
 }
 
+// resolve interpolates any variables in a policy.  if the policy ID resolves to a list,
+// it returns a list of resolved policies, each one with an ID from that list.
 func (p Policy) resolve(vaiables VariableResolver) (policies []Policy, err error) {
 
 	var resolvedPolicies []Policy
 
+	// If the policy ID is a variable, we need to resolve/expand it.  If the result is
+	// a list of IDs, we return a list of policies, each one with an ID from the list
 	if IsVariable(p.ID) {
 		resolvedIDs, err := vaiables.Resolve(p.ID)
 		if err != nil {
@@ -23,6 +28,8 @@ func (p Policy) resolve(vaiables VariableResolver) (policies []Policy, err error
 
 		for _, id := range resolvedIDs {
 
+			// Now that we have a concrete ID, resolve any other variables elsewhere in the
+			// policy.  Some of them may depend on knowing the ID we just found
 			resolved, err := Policy{
 				ID:           id,
 				Description:  p.Description,
@@ -37,7 +44,11 @@ func (p Policy) resolve(vaiables VariableResolver) (policies []Policy, err error
 			resolvedPolicies = append(resolvedPolicies, resolved...)
 		}
 	} else {
+
+		// Individual policy.  Resolve the repositories section, and filter by condition to see if
+		// it is applicable
 		resolvedPolicies = []Policy{p}
+
 		if p.Repositories, err = p.resolveRepositories(vaiables); err != nil {
 			return nil, errors.Wrapf(err, "could not resolve repositories in policy %s", p.ID)
 		}
@@ -50,6 +61,8 @@ func (p Policy) resolve(vaiables VariableResolver) (policies []Policy, err error
 	return resolvedPolicies, nil
 }
 
+// resolveRepositories replaces any variables in the repository section of a policy.  If repository ID
+// is a variable that expands into a list of IDs, then we can have multiple repositories.
 func (p Policy) resolveRepositories(variables VariableResolver) ([]Repository, error) {
 	var resolved []Repository
 	for _, repo := range p.Repositories {
@@ -63,9 +76,10 @@ func (p Policy) resolveRepositories(variables VariableResolver) ([]Repository, e
 	return resolved, nil
 }
 
+// Filter based on evaluating conditions, if there are any
 func (p Policy) applyConditions(variables VariableResolver) (bool, error) {
 	for _, cond := range p.Conditions {
-		if ok, err := cond.apply(variables); !ok || err != nil {
+		if ok, err := cond.Apply(variables); !ok || err != nil {
 			return ok, err
 		}
 	}

--- a/rule/policy_test.go
+++ b/rule/policy_test.go
@@ -1,0 +1,85 @@
+package rule_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/oa-pass/pass-policy-service/rule"
+)
+
+func TestPolicy(t *testing.T) {
+
+	submissionURI := "http://example.org/submission"
+
+	policyJSON := `{
+		"description": "Used for unit testing",
+		"policy-id": "${submission.foo.policy}",
+		"conditions": [
+			{
+				"endsWith": {
+					"good": "${submission.foo.policy}"
+				}
+			}
+		],
+		"repositories": [
+			{
+				"repository-id": "${policy.repository}",
+				"selected": true
+			},
+			{
+				"repository-id": "*"
+			}
+		]
+	}`
+
+	policy := rule.Policy{}
+
+	_ = json.Unmarshal([]byte(policyJSON), &policy)
+
+	policies, err := policy.Resolve(&rule.Context{
+		SubmissionURI: submissionURI,
+		PassClient: testFetcher(map[string]string{
+			submissionURI: `{
+				"foo": [
+					"http://example.org/foo/1",
+					"http://example.org/foo/2"
+				]
+			}`,
+			"http://example.org/foo/1": `{
+				"policy": "http://example.org/policy/1"
+			}`,
+			"http://example.org/foo/2": `{
+				"policy": "http://example.org/policy/2-good"
+			}`,
+			"http://example.org/policy/1": `{
+				"repository": ["a", "b"]
+			}`,
+			"http://example.org/policy/2-good": `{
+				"repository": ["c", "d"]
+			}`,
+		}),
+	})
+
+	if err != nil {
+		t.Fatalf("Failed policy resolve: %+v", err)
+	}
+
+	if len(policies) != 1 {
+		t.Fatalf("Wrong number of policies: %+v", policies)
+	}
+
+	var repos []string
+	for _, p := range policies {
+		for _, r := range p.Repositories {
+			repos = append(repos, r.ID)
+		}
+	}
+
+	diffs := deep.Equal(repos, []string{"c", "d", "*"})
+	if len(diffs) > 0 {
+		t.Fatalf("Found differences in expected repositories: %s", strings.Join(diffs, "\n"))
+	}
+
+}

--- a/rule/repository.go
+++ b/rule/repository.go
@@ -1,6 +1,35 @@
 package rule
 
+import (
+	"github.com/pkg/errors"
+)
+
 type Repository struct {
 	ID       string `json:"repository-id"`
 	Selected bool   `json:"selected"`
+}
+
+func (r Repository) Resolve(variables VariableResolver) ([]Repository, error) {
+	var resolvedRepositories []Repository
+
+	if IsVariable(r.ID) {
+		resolvedIDs, err := variables.Resolve(r.ID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not resolve property ID %s", r.ID)
+		}
+
+		for _, id := range resolvedIDs {
+			resolvedRepositories = append(resolvedRepositories,
+				Repository{
+					ID:       id,
+					Selected: r.Selected,
+				},
+			)
+		}
+	} else {
+		resolvedRepositories = []Repository{r}
+	}
+
+	return resolvedRepositories, nil
+
 }

--- a/rule/repository_test.go
+++ b/rule/repository_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/oa-pass/pass-policy-service/rule"
 )
 
-type testResolver map[string][]string
-
-func (t testResolver) Resolve(varString string) ([]string, error) {
-	return t[varString], nil
-}
-
 func TestResolveRepository(t *testing.T) {
 	cases := []struct {
 		testName   string

--- a/rule/repository_test.go
+++ b/rule/repository_test.go
@@ -1,0 +1,81 @@
+package rule_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/oa-pass/pass-policy-service/rule"
+)
+
+type testResolver map[string][]string
+
+func (t testResolver) Resolve(varString string) ([]string, error) {
+	return t[varString], nil
+}
+
+func TestResolveRepository(t *testing.T) {
+	cases := []struct {
+		testName   string
+		resolver   testResolver
+		repository rule.Repository
+		expected   []rule.Repository
+	}{
+		{
+			testName: "nothingToResolve",
+			repository: rule.Repository{
+				ID:       "foo",
+				Selected: true,
+			},
+			expected: []rule.Repository{{
+				ID:       "foo",
+				Selected: true,
+			}},
+		},
+		{
+			testName: "oneRepository",
+			repository: rule.Repository{
+				ID:       "${foo.bar}",
+				Selected: true,
+			},
+			expected: []rule.Repository{{
+				ID:       "foo",
+				Selected: true,
+			}},
+			resolver: map[string][]string{
+				"${foo.bar}": {"foo"},
+			},
+		},
+		{
+			testName: "multiRepository",
+			repository: rule.Repository{
+				ID:       "${foo.bar}",
+				Selected: true,
+			},
+			expected: []rule.Repository{{
+				ID:       "foo",
+				Selected: true,
+			}, {
+				ID:       "bar",
+				Selected: true,
+			}},
+			resolver: map[string][]string{
+				"${foo.bar}": {"foo", "bar"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.testName, func(t *testing.T) {
+			resolved, err := c.repository.Resolve(c.resolver)
+			if err != nil {
+				t.Fatalf("Error resolving repository %+v", err)
+			}
+			diffs := deep.Equal(resolved, c.expected)
+			if len(diffs) > 0 {
+				t.Fatalf("resolved repositories are not expected %+v", strings.Join(diffs, "\n"))
+			}
+		})
+	}
+}

--- a/rule/testdata/good.json
+++ b/rule/testdata/good.json
@@ -25,7 +25,7 @@
             "conditions": [
                 {
                     "endsWith": {
-                        "${header.Eppn}": "@johnshopkins.edu"
+                        "@johnshopkins.edu": "${header.Eppn}"
                     }
                 }
             ],

--- a/rule/testdata/good.json
+++ b/rule/testdata/good.json
@@ -3,19 +3,19 @@
     "policy-rules": [
         {
             "description": "Must deposit to one of the repositories indicated by primary funder",
-            "policy-id": "${submission.grants.primaryFunder.policy.id}",
+            "policy-id": "${submission.grants.primaryFunder.policy}",
             "repositories": [
                 {
-                    "repository-id": "${policy.repositories.id}"
+                    "repository-id": "${policy.repositories}"
                 }
             ]
         },
         {
             "description": "Must deposit to one of the repositories indicated by direct funder",
-            "policy-id": "${submission.grants.directFunder.policy.id}",
+            "policy-id": "${submission.grants.directFunder.policy}",
             "repositories": [
                 {
-                    "repository-id": "${policy.repositories.id}"
+                    "repository-id": "${policy.repositories}"
                 }
             ]
         },

--- a/rule/util_test.go
+++ b/rule/util_test.go
@@ -1,0 +1,46 @@
+package rule_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/oa-pass/pass-policy-service/rule"
+)
+
+type testResolver map[string][]string
+
+func (t testResolver) Resolve(varString string) ([]string, error) {
+	resolved, ok := t[varString]
+	if !ok {
+		return []string{varString}, nil
+	}
+	return resolved, nil
+}
+
+type errResolver struct{}
+
+func (errResolver) Resolve(varString string) ([]string, error) {
+	if rule.IsVariable(varString) {
+		return nil, fmt.Errorf("This always returns an error")
+	}
+	return []string{varString}, nil
+}
+
+// map of urls to json strings
+type testFetcher map[string]string
+
+// deserialize the json string into the given entity pointer
+func (f testFetcher) FetchEntity(url string, entityPointer interface{}) error {
+	jsonBlob, ok := f[url]
+	if !ok {
+		return fmt.Errorf("no value for key %s", url)
+	}
+
+	return json.Unmarshal([]byte(jsonBlob), entityPointer)
+}
+
+type errFetcher struct{}
+
+func (errFetcher) FetchEntity(url string, entityPointer interface{}) error {
+	return fmt.Errorf("This always returns an error")
+}

--- a/rule/validate.go
+++ b/rule/validate.go
@@ -51,7 +51,7 @@ func Validate(rulesDoc []byte) error {
 	}
 
 	// Serialize just to defend against programmer error
-	rules := Document{}
+	rules := DSL{}
 	decoder := json.NewDecoder(bytes.NewReader(rulesDoc))
 	decoder.DisallowUnknownFields()
 

--- a/rule/validate.go
+++ b/rule/validate.go
@@ -26,28 +26,28 @@ func (v validationErrors) Error() string {
 
 // Validate validates a serialized policy rules document with respect to
 // the implementation's expected JSON schema, and attempts to parse it.
-func Validate(rulesDoc []byte) error {
+func Validate(rulesDoc []byte) (*DSL, error) {
 	box := packr.New("myBox", "../schemas")
 	file, err := box.Open("policy_config_1.0.json")
 	if err != nil {
 		// Will only happen if internal schema is misnamed
-		return errors.Wrapf(err, "could not read schema")
+		return nil, errors.Wrapf(err, "could not read schema")
 	}
 
 	rs := &jsonschema.RootSchema{}
 	err = json.NewDecoder(file).Decode(rs)
 	if err != nil {
 		// WIll only happen if internal schema is malformed
-		return errors.Wrapf(err, "could not parse schema")
+		return nil, errors.Wrapf(err, "could not parse schema")
 	}
 
 	valErrors, err := rs.ValidateBytes(rulesDoc)
 	if err != nil {
-		return errors.Wrapf(err, "could not parse rules doc")
+		return nil, errors.Wrapf(err, "could not parse rules doc")
 	}
 
 	if len(valErrors) > 0 {
-		return validationErrors(valErrors)
+		return nil, validationErrors(valErrors)
 	}
 
 	// Serialize just to defend against programmer error
@@ -55,5 +55,5 @@ func Validate(rulesDoc []byte) error {
 	decoder := json.NewDecoder(bytes.NewReader(rulesDoc))
 	decoder.DisallowUnknownFields()
 
-	return decoder.Decode(&rules)
+	return &rules, decoder.Decode(&rules)
 }

--- a/rule/validate_test.go
+++ b/rule/validate_test.go
@@ -11,7 +11,7 @@ import (
 func TestValidateGoodData(t *testing.T) {
 	content, _ := ioutil.ReadFile("testdata/good.json")
 
-	err := rule.Validate(content)
+	_, err := rule.Validate(content)
 	if err != nil {
 		t.Fatalf("Validation failed: %+v", err)
 	}
@@ -29,7 +29,7 @@ func TestValidateBadData(t *testing.T) {
 	for name, content := range cases {
 		content := content
 		t.Run(name, func(t *testing.T) {
-			err := rule.Validate(content)
+			_, err := rule.Validate(content)
 			if err == nil {
 				t.Fatalf("Validation should have failed!")
 			}

--- a/rule/variable.go
+++ b/rule/variable.go
@@ -1,0 +1,71 @@
+package rule
+
+import (
+	"strings"
+)
+
+// variable encodes a variable for interpolation, eg. ${foo.bar.baz}, or a
+// segment of one, e.g. ${foo.bar} of ${foo.bar.baz}
+type variable struct {
+	segment     string // e.g. "bar" from ${foo.bar.baz}
+	segmentName string // e.g. "foo.bar" from ${foo.bar.baz}
+	fullName    string // e.g. "foo.bar.baz" from ${foo.bar.baz}
+}
+
+// IsVariable determines if a string is a variable (e.g. of the form '${foo.bar.baz}')
+func IsVariable(text string) bool {
+	return strings.HasPrefix(text, "${") &&
+		strings.HasSuffix(text, "}")
+}
+
+// toVariable creates a Variable from a string like '${foo.bar.baz}' (dollar sign and braces required)
+func toVariable(text string) (variable, bool) {
+	if !IsVariable(text) {
+		return variable{}, false
+	}
+
+	return variable{
+		fullName: strings.TrimRight(strings.TrimLeft(text, "${"), "}"),
+	}, true
+}
+
+// shift is used for producing a segment of a variable, e.g. Shift() of ${foo.bar.baz},
+// is ${foo}.  Shift() of that ${foo} is ${foo.bar}, and Shift() of ${foo.bar} is ${foo.bar.baz}
+func (v variable) shift() (variable, bool) {
+	remaining := strings.TrimLeft(strings.TrimPrefix(v.fullName, v.segmentName), ".")
+
+	// no more variable segments
+	if remaining == "" {
+		return v, false
+	}
+
+	shifted := variable{
+		fullName: v.fullName,
+	}
+
+	if v.segment == "" {
+		shifted.segment = strings.Split(v.fullName, ".")[0]
+		shifted.segmentName = shifted.segment
+	} else {
+		parts := strings.Split(remaining, ".")
+		shifted.segment = parts[0]
+		shifted.segmentName = strings.Join([]string{v.segmentName, parts[0]}, ".")
+	}
+
+	return shifted, true
+}
+
+func (v variable) prev() variable {
+	prev := variable{
+		fullName: v.fullName,
+	}
+	if v.segment == "" {
+		return prev
+	}
+
+	prev.segmentName = strings.Trim(strings.TrimSuffix(v.segmentName, v.segment), ".")
+	segments := strings.Split(prev.segmentName, ".")
+	prev.segment = segments[len(segments)-1]
+
+	return prev
+}

--- a/rule/variable.go
+++ b/rule/variable.go
@@ -12,6 +12,12 @@ type variable struct {
 	fullName    string // e.g. "foo.bar.baz" from ${foo.bar.baz}
 }
 
+type passThroughResolver struct{}
+
+func (passThroughResolver) Resolve(varString string) ([]string, error) {
+	return []string{varString}, nil
+}
+
 // IsVariable determines if a string is a variable (e.g. of the form '${foo.bar.baz}')
 func IsVariable(text string) bool {
 	return strings.HasPrefix(text, "${") &&

--- a/rule/variable.go
+++ b/rule/variable.go
@@ -12,6 +12,18 @@ type variable struct {
 	fullName    string // e.g. "foo.bar.baz" from ${foo.bar.baz}
 }
 
+// VariableResolver resolves a variable (a string of form "${foo.bar.baz}"), and returns
+// a list of values
+type VariableResolver interface {
+	Resolve(varString string) ([]string, error)
+}
+
+// VariablePinner is a variable resolver that can pin variables to specific values
+type VariablePinner interface {
+	VariableResolver
+	Pin(variable, value string) VariablePinner // return a VariablePinner that pins a variable to the given value
+}
+
 type passThroughResolver struct{}
 
 func (passThroughResolver) Resolve(varString string) ([]string, error) {

--- a/rule/variable_test.go
+++ b/rule/variable_test.go
@@ -1,0 +1,69 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestIsVariable(t *testing.T) {
+
+	cases := []struct {
+		testName     string
+		variableName string
+		expected     bool
+	}{
+		{"goodNoDots", "${foo}", true},
+		{"goodDots", "${foo.bar.baz}", true},
+		{"noBrackets", "$foo.bar.baz", false},
+		{"malformed", "${foo.bar.baz}xyz", false},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.testName, func(t *testing.T) {
+			if IsVariable(c.variableName) != c.expected {
+				t.Fatalf("variable status of %s was parsed incorrectly", c.variableName)
+			}
+
+			_, ok := toVariable(c.variableName)
+			if ok != c.expected {
+				t.Fatalf("error converting %s to variable", c.variableName)
+			}
+		})
+	}
+}
+
+func TestShift(t *testing.T) {
+	v, _ := toVariable("${foo.bar.baz}")
+	numSegments := 3
+
+	segments := []variable{{
+		segment:     "foo",
+		segmentName: "foo",
+		fullName:    "foo.bar.baz",
+	}, {
+		segment:     "bar",
+		segmentName: "foo.bar",
+		fullName:    "foo.bar.baz",
+	}, {
+		segment:     "baz",
+		segmentName: "foo.bar.baz",
+		fullName:    "foo.bar.baz",
+	}}
+
+	var i int
+	for part, ok := v.shift(); ok; part, ok = part.shift() {
+
+		diffs := deep.Equal(segments[i], part)
+		if len(diffs) != 0 {
+			t.Errorf("Found differences in variable segment %+v", diffs)
+		}
+
+		i++
+	}
+
+	if i < numSegments-1 {
+		t.Fatalf("Got %d segments, expected %d", i+1, numSegments)
+	}
+}


### PR DESCRIPTION
* Parses a rules DSL into a set of applicable policies
* Interpolates variables (e.g. `${submission.grants.directFunder.policy.repositories}`) by parsing JSON and following links
* Applies inclusion conditions for policies, for example:
```
    {
         "endsWith": {
             "@johnshopkins.edu": "${header.Eppn}"
         }
    }
```

Resolves #3 