### PR TITLE
Add Harvard policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ services:
 install: true
 
 script:
-  - go build ./...
+  - go install ./...
   - go test ./...
+  - pass-policy-service validate policies/*.json
   - docker-compose build policyservice
   - docker-compose pull fcrepo && docker-compose up -d && bash ./scripts/wait_for_docker.sh
   - go test -v -tags=integration ./... || docker logs policyservice 

--- a/policies/harvard.json
+++ b/policies/harvard.json
@@ -33,7 +33,7 @@
                 },
                 {
                     "contains": {
-                        "FACULTY": "${header.Ajp_Affiliation}"
+                        "FACULTY": "${header.Ajp_affiliation}"
                     }
                 }
             ],

--- a/policies/harvard.json
+++ b/policies/harvard.json
@@ -1,0 +1,77 @@
+{
+    "$schema": "https://oa-pass.github.io/pass-policy-service/schemas/policy_config_1.0.json",
+    "policy-rules": [
+        {
+            "description": "Must deposit to one of the repositories indicated by primary funder",
+            "policy-id": "${submission.grants.primaryFunder.policy}",
+            "type": "funder",
+            "repositories": [
+                {
+                    "repository-id": "${policy.repositories}"
+                }
+            ]
+        },
+        {
+            "description": "Must deposit to one of the repositories indicated by direct funder",
+            "policy-id": "${submission.grants.directFunder.policy}",
+            "type": "funder",
+            "repositories": [
+                {
+                    "repository-id": "${policy.repositories}"
+                }
+            ]
+        },
+        {
+            "description": "Faculty members must deposit into DASH",
+            "policy-id": "/policies/f9/b6/01/25/f9b60125-662d-4e03-a7b0-eec0df2b50de",
+            "type": "institution",
+            "conditions": [
+                {
+                    "endsWith": {
+                        "@harvard.edu": "${header.Ajp_eppn}"
+                    }
+                },
+                {
+                    "contains": {
+                        "FACULTY": "${header.Ajp_Affiliation}"
+                    }
+                }
+            ],
+            "repositories": [
+                {
+                    "repository-id": "/repositories/93/c5/ff/37/93c5ff37-ca2b-4652-a2af-3b6794ff8790"
+                }
+            ]
+        },
+        {
+            "description": "Non-faculty members may optionally deposit into DASH",
+            "policy-id": "/policies/f9/b6/01/25/f9b60125-662d-4e03-a7b0-eec0df2b50de",
+            "type": "institution",
+            "conditions": [
+                {
+                    "endsWith": {
+                        "@harvard.edu": "${header.Ajp_eppn}"
+                    }
+                },
+                {
+                    "noneOf": [
+                        {
+                            "contains": {
+                                "FACULTY": "${header.Ajp_Affiliation}"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "repositories": [
+                {
+                    "repository-id": "/repositories/93/c5/ff/37/93c5ff37-ca2b-4652-a2af-3b6794ff8790",
+                    "selected": true
+                },
+                {
+                    "repository-id": "*"
+                }
+            ]
+        }
+    ]
+}

--- a/rule/README.md
+++ b/rule/README.md
@@ -72,7 +72,12 @@ Policy inclusion rules are JSON objects containing the following fields:
 * `policy-id`:  a string containing a a single policy URI, or a variable substitution resulting in one or more policy URIs
   * In the case of a variable substitution resulting in many URIs, it is equivalent to creating multiple policy rules, each one containing a single policy-id from that list.  
 repositories:  contains a list of repository description JSON objects, specifying which repositories satisfy the given policy.
-* `condition`:  Optional.  JSON object describing a condition where the policy is included only if the condition evaluates to true.  If this field is not present, it is presumed that inclusion of the policy is unconditional
+* `condition`:  Optional.  JSON object describing a condition where the policy is included only if the condition evaluates to true.  If this field is not present, it is presumed that inclusion of the policy is unconditional.  See the schema for more details, but conditions include:
+  * `equals`: true if two strings are equal
+  * `endsWith`: true if a string ends with another
+  * `contains`: true if a string contains another as a substring
+  * `anyOf`: true if any of the given list of conditions are true
+  * `noneOf`: true if none of the given list of conditions are true
 
 Repositories are JSON objects with the following fields:
 

--- a/rule/condition.go
+++ b/rule/condition.go
@@ -25,6 +25,8 @@ func init() {
 		"endsWith": endsWith,
 		"equals":   equals,
 		"anyOf":    anyOf,
+		"noneOf":   noneOf,
+		"contains": contains,
 	}
 }
 
@@ -52,6 +54,11 @@ func (c Condition) Apply(variables VariableResolver) (bool, error) {
 func endsWith(fromCondition interface{}, variables VariableResolver) (bool, error) {
 
 	return eachPair(fromCondition, variables, strings.HasSuffix)
+}
+
+func contains(fromCondition interface{}, variables VariableResolver) (bool, error) {
+
+	return eachPair(fromCondition, variables, strings.Contains)
 }
 
 func equals(fromCondition interface{}, variables VariableResolver) (bool, error) {
@@ -84,6 +91,11 @@ func anyOf(arg interface{}, variables VariableResolver) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func noneOf(arg interface{}, variables VariableResolver) (bool, error) {
+	passes, err := anyOf(arg, variables)
+	return !passes, err
 }
 
 func eachPair(src interface{}, variables VariableResolver, test func(string, string) bool) (passes bool, err error) {

--- a/rule/condition_test.go
+++ b/rule/condition_test.go
@@ -33,11 +33,33 @@ func TestConditionApply(t *testing.T) {
 			]
 		}`,
 	}, {
+		expected: true,
+		json: `{
+			"noneOf": [
+				{"equals":{"one": "two"}},
+				{"endsWith":{"one": "goner"}}
+			]
+		}`,
+	}, {
+		expected: false,
+		json: `{
+			"noneOf": [
+				{"equals":{"one": "two"}},
+				{"endsWith":{"one": "gone"}}
+			]
+		}`,
+	}, {
 		expected: false,
 		json:     `{"equals":{"one": "two"}}`,
 	}, {
 		expected: true,
 		json:     `{"equals":{"two": "two"}}`,
+	}, {
+		expected: true,
+		json:     `{"contains": {"FACULTY": "STAFF,FACULTY,COW"}}`,
+	}, {
+		expected: false,
+		json:     `{"contains": {"BOVINE": "STAFF,FACULTY,COW"}}`,
 	}, {
 		expected: true,
 		json: `{

--- a/rule/testdata/good.json
+++ b/rule/testdata/good.json
@@ -30,6 +30,15 @@
                     "endsWith": {
                         "@johnshopkins.edu": "${header.Eppn}"
                     }
+                },
+                {
+                    "noneOf": [
+                        {
+                            "contains": {
+                                "foo": "${header.Foo}"
+                            }
+                        }
+                    ]
                 }
             ],
             "repositories": [

--- a/schemas/policy_config_1.0.json
+++ b/schemas/policy_config_1.0.json
@@ -79,6 +79,9 @@
                                 },
                                 {
                                     "$ref": "#/definitions/anyOf"
+                                },
+                                {
+                                    "$ref": "#/definitions/noneOf"
                                 }
                             ]
                         }
@@ -127,6 +130,25 @@
                             }
                         }
                     }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "contains"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "contains": {
+                            "type": "object",
+                            "title": "Contains",
+                            "description": "Evaluates to 'true' when the given value contains the key",
+                            "patternProperties": {
+                                "^.+$": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             ]
         },
@@ -138,6 +160,21 @@
             "additionalProperties": false,
             "properties": {
                 "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/condition"
+                    }
+                }
+            }
+        },
+        "noneOf": {
+            "type": "object",
+            "title": "None Of",
+            "description": "Evaluates to true when none the conditions listed within evaluate to true",
+            "required": ["noneOf"],
+            "additionalProperties": false,
+            "properties": {
+                "noneOf": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/condition"


### PR DESCRIPTION
* Adds a new Harvard policy `policies/harvard.json` that has the following characteristics
  * Requires any repository required by the policy of grant funders
  * For individuals whose Shib `Eppn` ends with `harvard.edu` (harvard community menbers)
    * For faculty (`Shib `Affiliation` contains `FACULTY`), requires deposit into DASH
    * For non-faculty, deposit into DASH is optional if there are any other required repositories

Also, updates the DSL to add a `noneOf` condition, and `contains` (for substring match), enhances the `validate` subcommand to allow validating multiple files, and adds a travis check to validate all schemas that are to be placed into the Docker image.

This can't be meaningfully human tested without Ember.  

To specify the Harvard schema to Docker at runtime, use `POLICY_FILE=harvard.json`

Resolves #16 